### PR TITLE
install credo only in dev and test

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -52,7 +52,7 @@ defmodule ExDbug.MixProject do
   defp deps do
     [
       # Testing
-      {:credo, "~> 1.7"},
+      {:credo, "~> 1.7", only: [:dev, :test], runtime: false},
       {:dialyxir, "~> 1.4", only: [:dev, :test], runtime: false},
       {:ex_doc, "~> 0.34", only: :dev, runtime: false}
     ]


### PR DESCRIPTION
Currently, it is impossible to have ex_dbug and Credo as dependencies when installing Credo in the recommended way. Credo recommends to only install it in the dev and test environments, but ex_dbug prevents this in its current state. This patch fixes that.

https://hexdocs.pm/credo/1.7.11/installation.html

Relevant error message:

```
Dependencies have diverged:
* credo (Hex package)
  the :only option for dependency credo

  > In mix.exs:
    {:credo, "~> 1.7", [env: :prod, hex: "credo", only: [:dev, :test], runtime: false, repo: "hexpm"]}

  does not match the :only option calculated for

  > In deps/ex_dbug/mix.exs:
    {:credo, "~> 1.7", [env: :prod, hex: "credo", repo: "hexpm", optional: false]}

  Remove the :only restriction from your dep
** (Mix) Can't continue due to errors on dependencies
```